### PR TITLE
This packages `imply` way too much

### DIFF
--- a/package.js
+++ b/package.js
@@ -18,12 +18,6 @@ Package.onUse(function(api) {
     'fabienb4:autoform-semantic-ui@0.4.5'
   ]);
 
-  api.imply([
-    'orionjs:core',
-    'aldeed:autoform',
-    'useraccounts:semantic-ui'
-  ]);
-
   api.addFiles([
     'lib/init.js',
     'lib/tabular.js'


### PR DESCRIPTION
I would like to complain a bit. The approach in this repository where so many packages are `imply`ed, makes it really hard to reuse this system with other Meteor packages. Why dependencies are also implied? It destroys the whole purpose of dependencies by creating one monolithic package you can or cannot use.

For example, it is now impossible to use `dvz:orion-semantic-ui` together with [Blaze Components](https://github.com/peerlibrary/meteor-blaze-components) because `dvz:orion-semantic-ui` implies `orionjs:core` which implies `orionjs:base` which implies `blaze-html-templates`. Why it has to imply it and not just depend on it? This makes it problematic for users who would like to swap `templating` with Blaze Components and get also server side rendering.
